### PR TITLE
Add new() constraint to AggregateRepository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ tools/**
 
 artifacts/
 BenchmarkDotNet.Artifacts/
+
+# VS
+
+.vs

--- a/src/Odyssey/CosmosEventStore.cs
+++ b/src/Odyssey/CosmosEventStore.cs
@@ -53,7 +53,7 @@ public sealed class CosmosEventStore : IEventStore
 
         if (_options.AutoCreateContainer)
         {
-            var containerResponse = await CreateContainerIfNotExists(_database, cancellationToken);
+            var containerResponse = await CreateContainerIfNotExists(_database, _options.ContainerId, cancellationToken);
             _container = containerResponse.Container;
         }
         else
@@ -67,11 +67,11 @@ public sealed class CosmosEventStore : IEventStore
         // );
     }
 
-    private static Task<ContainerResponse> CreateContainerIfNotExists(Database database, CancellationToken cancellationToken)
+    private static Task<ContainerResponse> CreateContainerIfNotExists(Database database, string containerId, CancellationToken cancellationToken)
     {
         var containerProperties = new ContainerProperties()
         {
-            Id = "events", // TODO make configurable
+            Id = containerId,
             IndexingPolicy = new IndexingPolicy
             {
                 IncludedPaths =

--- a/src/Odyssey/Model/AggregateRepository.cs
+++ b/src/Odyssey/Model/AggregateRepository.cs
@@ -12,16 +12,16 @@ public sealed class AggregateRepository<TId> : IAggregateRepository<TId>
         _eventStore = eventStore.NotNull();
     }
 
-    public Task<bool> Exists<T>(TId id, CancellationToken cancellationToken = default) where T : IAggregate<TId>
+    public Task<bool> Exists<T>(TId id, CancellationToken cancellationToken = default) where T : IAggregate<TId>, new()
     {
         throw new NotImplementedException();
     }
 
-    public async Task<T> GetById<T>(TId id, CancellationToken cancellationToken = default) where T : IAggregate<TId>
+    public async Task<T> GetById<T>(TId id, CancellationToken cancellationToken = default) where T : IAggregate<TId>, new()
     {
         string streamId = id?.ToString() ?? throw new ArgumentException("The string representation of the aggregate ID cannot be null", nameof(id));
 
-        var aggregate = Activator.CreateInstance<T>(); // TODO alternative to reflection
+        var aggregate = new T(); // TODO alternative to reflection
 
         IReadOnlyCollection<EventData> events
             = await _eventStore.ReadStream(streamId, ReadDirection.Forwards, StreamPosition.Start, cancellationToken);

--- a/src/Odyssey/Model/IAggregateRepository.cs
+++ b/src/Odyssey/Model/IAggregateRepository.cs
@@ -2,7 +2,7 @@ namespace Odyssey.Model;
 
 public interface IAggregateRepository<TId>
 {
-    Task<T> GetById<T>(TId id, CancellationToken cancellationToken) where T : IAggregate<TId>;
+    Task<T> GetById<T>(TId id, CancellationToken cancellationToken) where T : IAggregate<TId>, new();
     Task Save(IAggregate<TId> aggregate, CancellationToken cancellationToken);
-    Task<bool> Exists<T>(TId id, CancellationToken cancellationToken) where T : IAggregate<TId>;
+    Task<bool> Exists<T>(TId id, CancellationToken cancellationToken) where T : IAggregate<TId>, new();
 }


### PR DESCRIPTION
This PR add the `new()` constraint to the `T` parameter representing the Aggregate. 

`Activator.CreateInstance<T>()` works only if the class has a parameterless constructor, we are using the `new()` constraints to surface this requirement. 

We could revisit later this requirement since it is not always the case that having a parameterless constructor make sense for an aggregate.