### PR TITLE
Make Cosmos Throughput Properties Optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,38 @@ app.MapPost("/payments", async (PaymentRequest payment, IEventStore eventStore) 
     );
 });
 ```
+
+## Configuration
+
+By default Odyssey will attempt to create a Cosmos Database named `odyssey` and container named `events`.
+
+You can control these settings as well as the auto-create settings using the .NET configuration system, for example, in `appsettings.json`:
+
+```json
+  "Odyssey": {
+    "DatabaseId": "payments",
+    "ContainerId": "payment-events",
+    "AutoCreateDatabase": false,
+    "AutoCreateContainer": false
+  },
+```
+
+To initialize Odyssey with these settings, pass the relevant configuration section to Odyssey during initialization:
+
+```c#
+builder.Services.AddOdyssey(
+    configureOptions: options => options.DatabaseThroughputProperties = ThroughputProperties.CreateAutoscaleThroughput(1000),
+    cosmosClientFactory: _ => CreateClient(builder.Configuration),
+    builder.Configuration.GetSection("Odyssey")
+);
+
+static CosmosClient CreateClient(IConfiguration configuration)
+{
+    return new(
+        accountEndpoint: configuration["Cosmos:Endpoint"],
+        authKeyOrResourceToken: configuration["Cosmos:Token"]
+    );
+}
+```
+
+Note that this also demonstrates how to specify the throughput properties of the created Container.

--- a/examples/ApiExample/Program.cs
+++ b/examples/ApiExample/Program.cs
@@ -1,4 +1,3 @@
-using ApiExample;
 using ApiExample.Onboarding;
 using Microsoft.AspNetCore.Http.Json;
 using Microsoft.Azure.Cosmos;
@@ -14,8 +13,6 @@ builder.Services.Configure<JsonOptions>(
 builder.Services.AddOdyssey(cosmosClientFactory: _ => CreateClient(builder.Configuration));
 
 var app = builder.Build();
-
-using CosmosClient client = CreateClient(builder.Configuration);
 
 IEventStore eventStore = app.Services.GetRequiredService<IEventStore>();
 

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "6.0.300",
+    "rollForward": "latestMinor"
+  }
+}

--- a/src/Odyssey/CosmosEventStoreOptions.cs
+++ b/src/Odyssey/CosmosEventStoreOptions.cs
@@ -10,13 +10,11 @@ public class CosmosEventStoreOptions
         AutoCreateDatabase = true;
         ContainerId = "events";
         AutoCreateContainer = true;
-
-        DatabaseThroughputProperties = ThroughputProperties.CreateAutoscaleThroughput(1000);
     }
 
     public string DatabaseId { get; set; }
     public bool AutoCreateDatabase { get; set; }
-    public ThroughputProperties DatabaseThroughputProperties { get; set; }
     public string ContainerId { get; set; }
     public bool AutoCreateContainer { get; set; }
+    public ThroughputProperties? DatabaseThroughputProperties { get; set; }
 }

--- a/src/Odyssey/Odyssey.csproj
+++ b/src/Odyssey/Odyssey.csproj
@@ -9,14 +9,16 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="O9d.Guard" Version="0.1.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.2" />
-        <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.31.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[5.0,8.0)" />
-        <PackageReference Include="Microsoft.Extensions.Options" Version="[5.0,8.0)" />
-        <PackageReference Include="OneOf" Version="[3.0.160, 4.0)" />
+        <PackageReference Include="O9d.Guard" Version="0.1.0"/>
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.2"/>
+        <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.31.0"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[5.0,8.0)"/>
+        <PackageReference Include="Microsoft.Extensions.Options" Version="[5.0,8.0)"/>
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="[5.0,8.0)"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="[5.0,8.0)"/>
+        <PackageReference Include="OneOf" Version="[3.0.160, 4.0)"/>
     </ItemGroup>
 </Project>

--- a/src/Odyssey/OdysseyServiceCollectionExtensions.cs
+++ b/src/Odyssey/OdysseyServiceCollectionExtensions.cs
@@ -1,20 +1,28 @@
 namespace Odyssey;
 
 using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using O9d.Guard;
 
 public static class OdysseyServiceCollectionExtensions
 {
-    public static IServiceCollection AddOdyssey(this IServiceCollection services,
+    public static IServiceCollection AddOdyssey(
+        this IServiceCollection services,
         Action<CosmosEventStoreOptions>? configureOptions = null,
-        Func<IServiceProvider, CosmosClient>? cosmosClientFactory = null)
+        Func<IServiceProvider, CosmosClient>? cosmosClientFactory = null,
+        IConfiguration? configurationSection = null)
     {
         services.NotNull();
 
         if (cosmosClientFactory != null && !IsServiceRegistered<CosmosClient>(services))
         {
             services.AddSingleton(cosmosClientFactory);
+        }
+
+        if (configurationSection is not null)
+        {
+            services.Configure<CosmosEventStoreOptions>(configurationSection);
         }
 
         configureOptions ??= (_ => { });


### PR DESCRIPTION
Previously Odyssey would initialize the Cosmos Container with database throughput properties which would fail when using Cosmos serverless.

This PR makes those settings optional and documents configuration on the Readme.