### PR TITLE
Add option to specify leases database

### DIFF
--- a/src/Odyssey.Consumer/CosmosEventConsumerOptions.cs
+++ b/src/Odyssey.Consumer/CosmosEventConsumerOptions.cs
@@ -3,7 +3,8 @@ namespace Odyssey.EventConsumer;
 public class CosmosEventConsumerOptions
 {
     public string ProcessorName { get; set; } = "cosmos-event-consumer";
-    public string LeaseContainer { get; set; } = "leases";
     public string DatabaseId { get; set; } = "odyssey";
     public string ContainerId { get; set; } = "events";
+    public string LeaseContainerId { get; set; } = "leases";
+    public string? LeaseDatabaseId { get; set; }
 }


### PR DESCRIPTION
This PR:
- add a `LeaseDatabaseId` property on the consumer options type in order to support leases on a different database with respect to the one where we are the change feed is reading data
- Rename `LeaseContainer` to `LeaseContainerId`, this breaks compatibility but naming is more consistent. 