### PR TITLE
Test Utilities

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,7 +14,7 @@ insert_final_newline = false
 [*.js]
 indent_size = 2
 
-[*.json]
+[*.{json,jsonc}]
 indent_size = 2
 
 [*.{yml,yaml}]

--- a/src/Odyssey/EventStoreExtensions.cs
+++ b/src/Odyssey/EventStoreExtensions.cs
@@ -1,0 +1,32 @@
+using OneOf;
+
+namespace Odyssey;
+
+using AppendResult = OneOf<Success, UnexpectedStreamState>;
+
+public static class EventStoreExtensions
+{
+    /// <summary>
+    /// Copies events from one stream to another within the same event store instance
+    /// </summary>
+    /// <param name="sourceStore">The event store to copy streams from and to</param>
+    /// <param name="sourceStreamId">The source stream identifier</param>
+    /// <param name="destinationStreamId">The destination stream identifier</param>
+    /// <returns>The append result of the write</returns>
+    public static Task<AppendResult> CopyStream(this IEventStore sourceStore, string sourceStreamId, string destinationStreamId)
+        => CopyStream(sourceStore, sourceStreamId, sourceStore, destinationStreamId);
+
+    /// <summary>
+    /// Copies events from one stream in the source store to another in the destination store
+    /// </summary>
+    /// <param name="store">The event store to copy streams from and to</param>
+    /// <param name="sourceStreamId">The source stream identifier</param>
+    /// <param name="destinationStore">The</param>
+    /// <param name="destinationStreamId">The destination stream identifier. If not specified the <paramref name="sourceStreamId"/> will be used</param>
+    /// <returns>The append result of the write</returns>
+    public static async Task<AppendResult> CopyStream(this IEventStore sourceStore, string sourceStreamId, IEventStore destinationStore, string? destinationStreamId = null)
+    {
+        var eventsToCopy = await sourceStore.ReadStream(sourceStreamId, ReadDirection.Forwards, StreamPosition.Start);
+        return await destinationStore.AppendToStream(destinationStreamId ?? sourceStreamId, eventsToCopy.ToList(), StreamState.Any);
+    }
+}

--- a/src/Odyssey/ICloneable.cs
+++ b/src/Odyssey/ICloneable.cs
@@ -1,0 +1,14 @@
+namespace Odyssey;
+
+/// <summary>
+/// Interface for cloneable event stores (those that can be copied)
+/// </summary>
+public interface ICloneable
+{
+    /// <summary>
+    /// Copies all of the event streams from the event store instance to the target
+    /// </summary>
+    /// <param name="target">The target event store to write to</param>
+    /// <returns></returns>
+    Task CopyTo(IEventStore target, CancellationToken cancellationToken = default);
+}

--- a/src/Odyssey/JsonFileEventStore.cs
+++ b/src/Odyssey/JsonFileEventStore.cs
@@ -1,0 +1,163 @@
+namespace Odyssey;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using O9d.Guard;
+using OneOf;
+using OneOf.Types;
+
+/// <summary>
+/// Implementation of the event store that reads from files on disk
+/// </summary>
+public sealed class JsonFileEventStore : IEventStore, ICloneable
+{
+    private static readonly IReadOnlyCollection<EventData> EmptyStream = Array.Empty<EventData>();
+    private readonly Dictionary<string, List<EventData>> _appendedEvents = new();
+    private string _storagePath;
+    private readonly JsonSerializer _serializer;
+    private readonly TypeResolver _eventTypeResolver;
+
+    public JsonFileEventStore(string storagePath)
+    {
+        _storagePath = storagePath.NotNull();
+        _serializer = JsonSerializer.Create(SerializerSettings.Default);
+        _eventTypeResolver = TypeResolvers.UsingClrQualifiedTypeMetadata;
+    }
+
+    public Task<OneOf<Success, UnexpectedStreamState>> AppendToStream(string streamId, IReadOnlyList<EventData> events, StreamState expectedState, CancellationToken cancellationToken = default)
+    {
+        if (expectedState != StreamState.NoStream)
+        {
+            throw new InvalidOperationException("Appending to an existing stream is not currently supported");
+        }
+
+        using var sw = new StreamWriter(GetStreamFilePath(streamId));
+        using var writer = new JsonTextWriter(sw);
+        _serializer.Serialize(writer, events);
+        return Task.FromResult<OneOf<Success, UnexpectedStreamState>>(new Success());
+    }
+
+    public Task Initialize(CancellationToken cancellationToken = default)
+    {
+        if (!Directory.Exists(_storagePath))
+        {
+            Directory.CreateDirectory(_storagePath);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public async Task<IReadOnlyCollection<EventData>> ReadStream(string streamId, ReadDirection direction, StreamPosition position, CancellationToken cancellationToken = default)
+    {
+        // TODO support json or jsonc
+        string streamFilePath = GetStreamFilePath(streamId);
+
+        if (!File.Exists(streamFilePath))
+        {
+            return EmptyStream;
+        }
+
+        string fileJson = await File.ReadAllTextAsync(streamFilePath);
+        var fileEvents = JsonConvert.DeserializeObject<IEnumerable<JsonFileEvent>>(fileJson) ?? Array.Empty<JsonFileEvent>();
+
+        var events = new List<EventData>();
+
+        foreach (JsonFileEvent fileEvent in fileEvents)
+        {
+            EventData eventData = ResolveEvent(fileEvent);
+            events.Add(eventData);
+        }
+
+        if (_appendedEvents.ContainsKey(streamId))
+        {
+            events.AddRange(_appendedEvents[streamId]);
+        }
+
+        return events.AsReadOnly();
+    }
+
+    private string GetStreamFilePath(string streamId) => Path.Combine(_storagePath, $"{streamId}.jsonc");
+
+    public async Task<OneOf<EventData, NotFound>> ReadStreamEvent(string streamId, long eventNumber, CancellationToken cancellationToken = default)
+    {
+        var events = await ReadStream(streamId, ReadDirection.Forwards, StreamPosition.Start, cancellationToken);
+
+        if (eventNumber > events.Count - 1)
+        {
+            return new NotFound();
+        }
+
+        return events.ElementAt((int)eventNumber);
+    }
+
+    public void ClearAppendedEvents() => _appendedEvents.Clear();
+
+    private EventData ResolveEvent(JsonFileEvent @event)
+    {
+        Type? eventType = _eventTypeResolver.Invoke(@event.Id, @event.Metadata);
+
+        return eventType is not null
+            ? @event.ToEventData(eventType, _serializer)
+            : throw new ArgumentException($"The CLR type for event {@event.EventType} cannot be resolved");
+    }
+
+    public async Task CopyTo(IEventStore target, CancellationToken cancellationToken = default)
+    {
+        target.NotNull();
+        foreach (var streamId in GetStreamsFromDirectory())
+        {
+            var @events = await ReadStream(streamId, ReadDirection.Forwards, StreamPosition.Start, cancellationToken);
+            await target.AppendToStream(streamId, @events.ToList(), StreamState.NoStream, cancellationToken);
+        }
+    }
+
+    private IEnumerable<string> GetStreamsFromDirectory()
+    {
+        return Directory.GetFiles(_storagePath)
+            .Select(path => Path.GetFileNameWithoutExtension(path));
+    }
+
+    public sealed class JsonFileEvent
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; } = null!;
+
+        [JsonProperty("stream_id")] // PK
+        public string StreamId { get; set; } = null!;
+
+        [JsonProperty("event_id")]
+        public Guid EventId { get; set; }
+
+        [JsonProperty("event_type")]
+        public string EventType { get; set; } = null!;
+
+        [JsonProperty("data")]
+        public JObject Data { get; set; } = null!;
+
+        [JsonProperty("metadata")]
+        public Dictionary<string, object> Metadata { get; set; } = null!;
+
+        [JsonProperty("event_number")]
+        public long EventNumber { get; set; }
+
+        // https://learn.microsoft.com/en-us/azure/cosmos-db/account-databases-containers-items#properties-of-an-item
+        [JsonProperty("_ts")] // Unix time
+        public long? Timestamp { get; set; }
+
+        public EventData ToEventData(Type clrType, JsonSerializer serializer)
+        {
+            var eventData = new EventData(
+                EventId,
+                EventType,
+                Data.ToObject(clrType, serializer)!,
+                Metadata
+            )
+            {
+                EventNumber = EventNumber
+            };
+
+            return eventData;
+        }
+
+        public static string GenerateId(long eventNumber, string streamId) => $"{eventNumber}@{streamId}";
+    }
+}

--- a/src/Odyssey/Odyssey.csproj
+++ b/src/Odyssey/Odyssey.csproj
@@ -12,13 +12,13 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="O9d.Guard" Version="0.1.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[6.0.0, 8.0.0)" />
-        <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.31.2" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[6.0.0, 8.0.0)" />
-        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="[6.0.0, 8.0.0)" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="[6.0.0, 8.0.0)" />
-        <PackageReference Include="OneOf" Version="[3.0.223, 4.0)" />
-        <PackageReference Include="MinVer" Version="4.2.0" PrivateAssets="All" />
+        <PackageReference Include="O9d.Guard" Version="0.1.0"/>
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[6.0.0, 8.0.0)"/>
+        <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.31.2"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[6.0.0, 8.0.0)"/>
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="[6.0.0, 8.0.0)"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="[6.0.0, 8.0.0)"/>
+        <PackageReference Include="OneOf" Version="[3.0.223, 4.0)"/>
+        <PackageReference Include="MinVer" Version="4.2.0" PrivateAssets="All"/>
     </ItemGroup>
 </Project>

--- a/test/Odyssey.Tests/EventStoreExtensionsTests.cs
+++ b/test/Odyssey.Tests/EventStoreExtensionsTests.cs
@@ -1,0 +1,56 @@
+
+namespace Odyssey.Tests;
+
+using static Utils;
+
+public class EventStoreExtensionsTests
+{
+    [Fact]
+    public async Task Copies_streams_within_same_store()
+    {
+        var store = new InMemoryEventStore();
+        string streamId = CreateStreamId();
+
+        await store.AppendToStream(streamId, new[] { MapEvent(new TestEvent()) }, StreamState.NoStream);
+
+        string newStreamId = CreateStreamId();
+        var result = await store.CopyStream(streamId, newStreamId);
+
+        result.Value.ShouldBeOfType<Success>();
+        var events = await store.ReadStream(newStreamId, ReadDirection.Backwards, StreamPosition.Start);
+        events.Count().ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task Copies_streams_to_different_store()
+    {
+        var store = new InMemoryEventStore();
+        string streamId = CreateStreamId();
+        await store.AppendToStream(streamId, new[] { MapEvent(new TestEvent()) }, StreamState.NoStream);
+
+
+        var target = new InMemoryEventStore();
+        var result = await store.CopyStream(streamId, target);
+
+        result.Value.ShouldBeOfType<Success>();
+        var events = await target.ReadStream(streamId, ReadDirection.Backwards, StreamPosition.Start);
+        events.Count().ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task Copies_streams_to_different_store_and_stream_id()
+    {
+        var store = new InMemoryEventStore();
+        string streamId = CreateStreamId();
+        await store.AppendToStream(streamId, new[] { MapEvent(new TestEvent()) }, StreamState.NoStream);
+
+
+        var target = new InMemoryEventStore();
+        var targetStreamId = CreateStreamId();
+        var result = await store.CopyStream(streamId, target, targetStreamId);
+
+        result.Value.ShouldBeOfType<Success>();
+        var events = await target.ReadStream(targetStreamId, ReadDirection.Backwards, StreamPosition.Start);
+        events.Count().ShouldBe(1);
+    }
+}

--- a/test/Odyssey.Tests/Globals.cs
+++ b/test/Odyssey.Tests/Globals.cs
@@ -1,0 +1,1 @@
+global using Shouldly;

--- a/test/Odyssey.Tests/InMemoryEventStoreTests.cs
+++ b/test/Odyssey.Tests/InMemoryEventStoreTests.cs
@@ -83,6 +83,19 @@ public class InMemoryEventStoreTests
         events.Count.ShouldBe(0);
     }
 
+    [Fact]
+    public async Task Can_be_cloned()
+    {
+        var streamId = Guid.NewGuid().ToString();
+        await _eventStore.AppendToStream(streamId, new[] { Map(new TestEvent()) }, StreamState.NoStream);
+
+        var clone = new InMemoryEventStore();
+        await _eventStore.CopyTo(clone);
+
+        var events = await _eventStore.ReadStream(streamId, ReadDirection.Backwards, StreamPosition.Start);
+        events.Count().ShouldBe(1);
+    }
+
     static EventData Map<TEvent>(TEvent @event)
         => new(Guid.NewGuid(), @event!.GetType().Name, @event);
 

--- a/test/Odyssey.Tests/InMemoryEventStoreTests.cs
+++ b/test/Odyssey.Tests/InMemoryEventStoreTests.cs
@@ -1,5 +1,5 @@
 namespace Odyssey.Tests;
-
+using static Utils;
 using Shouldly;
 
 public class InMemoryEventStoreTests
@@ -17,7 +17,7 @@ public class InMemoryEventStoreTests
         var streamId = Guid.NewGuid().ToString();
 
         var @event = new TestEvent();
-        await _eventStore.AppendToStream(streamId, new[] { Map(@event) }, StreamState.Any);
+        await _eventStore.AppendToStream(streamId, new[] { MapEvent(@event) }, StreamState.Any);
 
         var events = await _eventStore.ReadStream(streamId, ReadDirection.Forwards, StreamPosition.Start);
         events.Count.ShouldBe(1);
@@ -28,9 +28,9 @@ public class InMemoryEventStoreTests
     public async Task Returns_unexpected_when_stream_should_not_exist_but_does()
     {
         var streamId = Guid.NewGuid().ToString();
-        await _eventStore.AppendToStream(streamId, new[] { Map(new TestEvent()) }, StreamState.NoStream);
+        await _eventStore.AppendToStream(streamId, new[] { MapEvent(new TestEvent()) }, StreamState.NoStream);
 
-        var result = await _eventStore.AppendToStream(streamId, new[] { Map(new TestEvent()) }, StreamState.NoStream);
+        var result = await _eventStore.AppendToStream(streamId, new[] { MapEvent(new TestEvent()) }, StreamState.NoStream);
         result.Value.ShouldBeOfType<UnexpectedStreamState>();
     }
 
@@ -38,7 +38,7 @@ public class InMemoryEventStoreTests
     public async Task Returns_unexpected_when_stream_should_exist_but_doesnt()
     {
         var streamId = Guid.NewGuid().ToString();
-        var result = await _eventStore.AppendToStream(streamId, new[] { Map(new TestEvent()) }, StreamState.StreamExists);
+        var result = await _eventStore.AppendToStream(streamId, new[] { MapEvent(new TestEvent()) }, StreamState.StreamExists);
         result.Value.ShouldBeOfType<UnexpectedStreamState>();
     }
 
@@ -47,9 +47,9 @@ public class InMemoryEventStoreTests
     {
         var streamId = Guid.NewGuid().ToString();
 
-        await _eventStore.AppendToStream(streamId, new[] { Map(new TestEvent()) }, StreamState.NoStream);
-        await _eventStore.AppendToStream(streamId, new[] { Map(new TestEvent()) }, StreamState.StreamExists);
-        var result = await _eventStore.AppendToStream(streamId, new[] { Map(new TestEvent()) }, StreamState.AtVersion(0));
+        await _eventStore.AppendToStream(streamId, new[] { MapEvent(new TestEvent()) }, StreamState.NoStream);
+        await _eventStore.AppendToStream(streamId, new[] { MapEvent(new TestEvent()) }, StreamState.StreamExists);
+        var result = await _eventStore.AppendToStream(streamId, new[] { MapEvent(new TestEvent()) }, StreamState.AtVersion(0));
         // Stream now at 1
 
         result.Value.ShouldBeOfType<UnexpectedStreamState>();
@@ -59,9 +59,9 @@ public class InMemoryEventStoreTests
     public async Task Can_read_stream_backwards()
     {
         var streamId = Guid.NewGuid().ToString();
-        await _eventStore.AppendToStream(streamId, new[] { Map(new TestEvent()) }, StreamState.NoStream);
-        await _eventStore.AppendToStream(streamId, new[] { Map(new TestEvent()) }, StreamState.AtVersion(0));
-        await _eventStore.AppendToStream(streamId, new[] { Map(new TestEvent()) }, StreamState.AtVersion(1));
+        await _eventStore.AppendToStream(streamId, new[] { MapEvent(new TestEvent()) }, StreamState.NoStream);
+        await _eventStore.AppendToStream(streamId, new[] { MapEvent(new TestEvent()) }, StreamState.AtVersion(0));
+        await _eventStore.AppendToStream(streamId, new[] { MapEvent(new TestEvent()) }, StreamState.AtVersion(1));
 
         var events = await _eventStore.ReadStream(streamId, ReadDirection.Backwards, StreamPosition.Start);
 
@@ -73,7 +73,7 @@ public class InMemoryEventStoreTests
     public async Task Can_remove_stream()
     {
         var streamId = Guid.NewGuid().ToString();
-        await _eventStore.AppendToStream(streamId, new[] { Map(new TestEvent()) }, StreamState.NoStream);
+        await _eventStore.AppendToStream(streamId, new[] { MapEvent(new TestEvent()) }, StreamState.NoStream);
 
         var events = await _eventStore.ReadStream(streamId, ReadDirection.Backwards, StreamPosition.Start);
         events.Count().ShouldBe(1);
@@ -87,7 +87,7 @@ public class InMemoryEventStoreTests
     public async Task Can_be_cloned()
     {
         var streamId = Guid.NewGuid().ToString();
-        await _eventStore.AppendToStream(streamId, new[] { Map(new TestEvent()) }, StreamState.NoStream);
+        await _eventStore.AppendToStream(streamId, new[] { MapEvent(new TestEvent()) }, StreamState.NoStream);
 
         var clone = new InMemoryEventStore();
         await _eventStore.CopyTo(clone);
@@ -95,9 +95,4 @@ public class InMemoryEventStoreTests
         var events = await _eventStore.ReadStream(streamId, ReadDirection.Backwards, StreamPosition.Start);
         events.Count().ShouldBe(1);
     }
-
-    static EventData Map<TEvent>(TEvent @event)
-        => new(Guid.NewGuid(), @event!.GetType().Name, @event);
-
-    private record TestEvent;
 }

--- a/test/Odyssey.Tests/JsonFileEventStoreTests.cs
+++ b/test/Odyssey.Tests/JsonFileEventStoreTests.cs
@@ -1,0 +1,60 @@
+namespace Odyssey.Tests;
+
+using O9d.Guard;
+using static Utils;
+
+public class JsonFileEventStoreTests
+{
+    [Fact]
+    public async Task Can_read_json_file_events()
+    {
+        var eventStore = new JsonFileEventStore("event-streams");
+        var streamId = "test-stream";
+
+        var events = await eventStore.ReadStream(streamId, ReadDirection.Forwards, StreamPosition.Start);
+        events.Count.ShouldBe(1);
+        var eventData = events.First();
+
+        var @event = eventData.Data.ShouldBeOfType<JsonEvent>();
+
+        var expected = new JsonEvent("Did the thing");
+        @event.ShouldBe(expected);
+    }
+
+    [Fact]
+    public async Task Can_read_event_at_index()
+    {
+        var eventStore = new JsonFileEventStore("event-streams");
+        var streamId = "test-stream";
+
+        var result = await eventStore.ReadStreamEvent(streamId, 0);
+        result.Value.ShouldBeOfType<EventData>().NotNull();
+    }
+
+    [Fact]
+    public async void Can_clone()
+    {
+        var eventStore = new JsonFileEventStore("event-streams");
+        var inMemStore = new InMemoryEventStore();
+
+        await eventStore.CopyTo(inMemStore);
+        var events = await inMemStore.ReadStream("test-stream", ReadDirection.Backwards, StreamPosition.Start);
+        events.Count().ShouldBe(1);
+    }
+
+    [Fact]
+    public async void Can_write_and_read_events()
+    {
+        var eventStore = new JsonFileEventStore("temp");
+        await eventStore.Initialize();
+
+        string streamId = CreateStreamId();
+        var @event = new JsonEvent("some reference");
+        await eventStore.AppendToStream(streamId, new[] { MapEvent(@event) }, StreamState.NoStream);
+
+        var events = await eventStore.ReadStream(streamId, ReadDirection.Backwards, StreamPosition.Start);
+        events.Count().ShouldBe(1);
+    }
+}
+
+public record JsonEvent(string Reference);

--- a/test/Odyssey.Tests/Odyssey.Tests.csproj
+++ b/test/Odyssey.Tests/Odyssey.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net7.0</TargetFrameworks>
+        <TargetFramework>net7.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>

--- a/test/Odyssey.Tests/Odyssey.Tests.csproj
+++ b/test/Odyssey.Tests/Odyssey.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net7.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>

--- a/test/Odyssey.Tests/Odyssey.Tests.csproj
+++ b/test/Odyssey.Tests/Odyssey.Tests.csproj
@@ -20,5 +20,8 @@
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\..\src\Odyssey\Odyssey.csproj"/>
+        <None Update="event-streams/*.json*">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
     </ItemGroup>
 </Project>

--- a/test/Odyssey.Tests/SnapshotTests.cs
+++ b/test/Odyssey.Tests/SnapshotTests.cs
@@ -1,0 +1,23 @@
+namespace Odyssey.Tests;
+
+using static Utils;
+
+public class SnapshotTests
+{
+    [Fact]
+    public async Task Can_create_and_restore_snapshotsAsync()
+    {
+        var store = new InMemoryEventStore();
+
+        var streamId = Guid.NewGuid().ToString();
+        await store.AppendToStream(streamId, new[] { MapEvent(new TestEvent()) }, StreamState.NoStream);
+
+        string snapShotId = await store.CreateSnapshot();
+
+        await store.AppendToStream(streamId, new[] { MapEvent(new TestEvent()) }, StreamState.StreamExists);
+        (await store.ReadStream(streamId, ReadDirection.Backwards, StreamPosition.Start)).Count.ShouldBe(2);
+
+        await store.RestoreFromSnapshot(snapShotId, true);
+        (await store.ReadStream(streamId, ReadDirection.Backwards, StreamPosition.Start)).Count.ShouldBe(1);
+    }
+}

--- a/test/Odyssey.Tests/TestEvent.cs
+++ b/test/Odyssey.Tests/TestEvent.cs
@@ -1,0 +1,3 @@
+namespace Odyssey.Tests;
+
+public record TestEvent;

--- a/test/Odyssey.Tests/Utils.cs
+++ b/test/Odyssey.Tests/Utils.cs
@@ -1,0 +1,9 @@
+namespace Odyssey.Tests;
+
+internal static class Utils
+{
+    public static EventData MapEvent<TEvent>(TEvent @event)
+        => new(Guid.NewGuid(), @event!.GetType().Name, @event);
+
+    public static string CreateStreamId() => Guid.NewGuid().ToString();
+}

--- a/test/Odyssey.Tests/event-streams/test-stream.jsonc
+++ b/test/Odyssey.Tests/event-streams/test-stream.jsonc
@@ -1,0 +1,16 @@
+[
+  {
+    "id": "0@test-stream",
+    "stream_id": "test-stream",
+    "event_id": "3766c7f2-ac53-4f1c-bc51-4c5f28757e26",
+    "event_type": "json_event",
+    "data": {
+      "reference": "Did the thing"
+    },
+    "metadata": {
+      "_clr_type": "Odyssey.Tests.JsonEvent, Odyssey.Tests",
+      "_clr_type_name": "JsonEvent"
+    },
+    "event_number": 0
+  }
+]


### PR DESCRIPTION
This PR adds a number of features to aid testing Odyssey:

- The ability to clone event store instances via the `ICloneable` interface
- The ability to snapshot the `InMemoryEventStore` so that it can be restored back to a known state between test runs
- Extensions for copying streams within a single event store instance and between event store instances
- A Json file event store which can be helpful for loading initial state from disk